### PR TITLE
feat: add core libraries and Aztec node/connector services

### DIFF
--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -1,0 +1,36 @@
+// App-level config. Single source of truth for identity, node URL, and timing.
+
+/** App identity used in wallet-sdk handshakes and capability manifests. */
+export const APP_ID = "web-boiler";
+
+/** Default Aztec testnet RPC; override with VITE_AZTEC_NODE_URL in your .env. */
+export const DEFAULT_NODE_URL = "https://rpc.testnet.aztec-labs.com";
+
+// `||` (not `??`) so a present-but-blank env var also falls back to the default.
+/** Resolved node URL: the env var if set, otherwise the testnet default. */
+export const NODE_URL =
+  (import.meta.env.VITE_AZTEC_NODE_URL as string | undefined) ||
+  DEFAULT_NODE_URL;
+
+/** How long wallet discovery waits before giving up (ms). */
+export const DISCOVERY_TIMEOUT_MS = 30_000;
+
+/** A selectable Aztec network (node RPC the app talks to). */
+export interface NetworkConfig {
+  id: string;
+  label: string;
+  nodeUrl: string;
+}
+
+// NOTE: keep these in sync with the app's pinned @aztec/* version.
+export const NETWORKS: NetworkConfig[] = [
+  { id: "testnet", label: "Testnet", nodeUrl: NODE_URL },
+  { id: "localhost", label: "Localhost", nodeUrl: "http://localhost:8080" },
+];
+
+export const DEFAULT_NETWORK_ID = "testnet";
+
+/** Look up a network by id, falling back to the first one. */
+export function getNetwork(id: string): NetworkConfig {
+  return NETWORKS.find((n) => n.id === id) ?? NETWORKS[0];
+}

--- a/src/lib/connectors/embedded.ts
+++ b/src/lib/connectors/embedded.ts
@@ -1,0 +1,36 @@
+// Embedded wallet connector (@aztec/wallets/embedded).
+// proverEnabled: true — the in-browser PXE generates real client-side proofs,
+// so the same connector keeps working once you extend the base to send
+// transactions (the read-only base never proves; the example tag will).
+// `ephemeral` is left unset => the account persists in IndexedDB, so
+// reconnecting reuses the existing Schnorr account.
+import { EmbeddedWallet } from "@aztec/wallets/embedded";
+import { Fr } from "@aztec/aztec.js/fields";
+import type { ConnectOptions, ConnectResult, WalletConnector } from "./types";
+
+export class EmbeddedConnector implements WalletConnector {
+  readonly kind = "embedded" as const;
+  readonly label = "Embedded wallet";
+
+  async connect({ node }: ConnectOptions): Promise<ConnectResult> {
+    // Use `pxe` (not the deprecated `pxeConfig`) in 4.3.0.
+    const wallet = await EmbeddedWallet.create(node, {
+      pxe: { proverEnabled: true },
+    });
+
+    // Reconnect: reuse a persisted account if present; otherwise create a
+    // Schnorr account. The signing key is derived automatically when omitted.
+    const accounts = await wallet.getAccounts();
+    if (accounts.length === 0) {
+      await wallet.createSchnorrAccount(Fr.random(), Fr.random());
+    }
+
+    // Return the full account list; the store auto-selects when there's one.
+    return { wallet, accounts: await wallet.getAccounts() };
+  }
+
+  async disconnect(): Promise<void> {
+    // No remote teardown nor local state to clean up: the account lives in
+    // IndexedDB (persisted). The store resets its wallet reference.
+  }
+}

--- a/src/lib/connectors/embedded.ts
+++ b/src/lib/connectors/embedded.ts
@@ -12,11 +12,22 @@ export class EmbeddedConnector implements WalletConnector {
   readonly kind = "embedded" as const;
   readonly label = "Embedded wallet";
 
+  // Active wallet, kept so disconnect() can stop its in-browser PXE.
+  private wallet: EmbeddedWallet | null = null;
+
   async connect({ node }: ConnectOptions): Promise<ConnectResult> {
+    // Tear down a previous PXE before spinning up a new one (e.g. on a
+    // network switch -> reconnect) so prover/worker resources don't leak.
+    if (this.wallet) {
+      await this.wallet.stop();
+      this.wallet = null;
+    }
+
     // Use `pxe` (not the deprecated `pxeConfig`) in 4.3.0.
     const wallet = await EmbeddedWallet.create(node, {
       pxe: { proverEnabled: true },
     });
+    this.wallet = wallet;
 
     // Reconnect: reuse a persisted account if present; otherwise create a
     // Schnorr account. The signing key is derived automatically when omitted.
@@ -30,7 +41,12 @@ export class EmbeddedConnector implements WalletConnector {
   }
 
   async disconnect(): Promise<void> {
-    // No remote teardown nor local state to clean up: the account lives in
-    // IndexedDB (persisted). The store resets its wallet reference.
+    // Stop the in-browser PXE (prover + workers) so it doesn't leak across
+    // reconnects. The account itself stays in IndexedDB (persisted), so a
+    // later reconnect reuses the same Schnorr account.
+    if (this.wallet) {
+      await this.wallet.stop();
+      this.wallet = null;
+    }
   }
 }

--- a/src/lib/connectors/external.ts
+++ b/src/lib/connectors/external.ts
@@ -1,0 +1,96 @@
+// External wallet connector (@aztec/wallet-sdk/manager — WalletManager).
+// Azguard-style flow: discovery via extension -> secure-channel handshake ->
+// emoji verification -> confirm() -> Wallet.
+import {
+  WalletManager,
+  type WalletProvider,
+} from '@aztec/wallet-sdk/manager';
+import { hashToEmoji } from '@aztec/wallet-sdk/crypto';
+import type {
+  AppCapabilities,
+  GrantedAccountsCapability,
+} from '@aztec/aztec.js/wallet';
+import { getChainInfo } from '../../services/node';
+import { APP_ID, DISCOVERY_TIMEOUT_MS } from '../../config/app';
+import type { ConnectOptions, ConnectResult, WalletConnector } from './types';
+
+/** Take the first provider from the async iterator, or null if discovery is empty. */
+async function firstProvider(
+  wallets: AsyncIterable<WalletProvider>,
+): Promise<WalletProvider | null> {
+  for await (const provider of wallets) {
+    return provider;
+  }
+  return null;
+}
+
+export class ExternalConnector implements WalletConnector {
+  readonly kind = 'external' as const;
+  readonly label = 'Azguard';
+
+  // Active provider, kept so disconnect() can tear it down.
+  private provider: WalletProvider | null = null;
+
+  async connect({ node, onEmojiGrid }: ConnectOptions): Promise<ConnectResult> {
+    const chainInfo = await getChainInfo(node);
+    const discovery = WalletManager.configure({
+      extensions: { enabled: true },
+    }).getAvailableWallets({
+      chainInfo,
+      appId: APP_ID,
+      timeout: DISCOVERY_TIMEOUT_MS,
+    });
+
+    const provider = await firstProvider(discovery.wallets);
+    discovery.cancel();
+    if (!provider) {
+      throw new Error('No external wallet found');
+    }
+    this.provider = provider;
+
+    // Handshake: establish the secure channel (key exchange).
+    const pending = await provider.establishSecureChannel(APP_ID);
+
+    // Show the emoji grid for the user to compare against their wallet — but do
+    // NOT block on a confirm button. We proceed straight to confirm(), which
+    // hands control to the wallet (Azguard) to approve the connection + grant
+    // capabilities below. The grid stays on screen (the UI keeps it open while
+    // status === 'connecting') so the user can compare while the wallet prompts.
+    onEmojiGrid?.(hashToEmoji(pending.verificationHash));
+
+    const wallet = await pending.confirm();
+
+    // External wallets (Azguard) use a capability/permission model: the dApp must
+    // declare upfront which methods it needs. Without this, getAccounts() fails with
+    // "Unauthorized method/chain". We request the minimal `accounts` capability —
+    // the wallet shows a permission prompt and returns the granted accounts.
+    const manifest: AppCapabilities = {
+      version: '1.0',
+      metadata: {
+        name: 'web-boiler',
+        version: '0.1.0',
+        description: 'Aztec frontend boilerplate',
+      },
+      capabilities: [{ type: 'accounts', canGet: true, canCreateAuthWit: true }],
+    };
+    const response = await wallet.requestCapabilities(manifest);
+
+    const accountsCap = response.granted.find(
+      (cap): cap is GrantedAccountsCapability => cap.type === 'accounts',
+    );
+    const accounts = accountsCap?.accounts ?? [];
+    if (accounts.length === 0) {
+      throw new Error('No accounts granted by the external wallet');
+    }
+    // Return ALL granted accounts; the store lets the user pick which one
+    // (the wallet may grant several). No more silent accounts[0].
+    return { wallet, accounts };
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.provider) {
+      await this.provider.disconnect();
+      this.provider = null;
+    }
+  }
+}

--- a/src/lib/connectors/external.ts
+++ b/src/lib/connectors/external.ts
@@ -1,22 +1,19 @@
 // External wallet connector (@aztec/wallet-sdk/manager — WalletManager).
 // Azguard-style flow: discovery via extension -> secure-channel handshake ->
 // emoji verification -> confirm() -> Wallet.
-import {
-  WalletManager,
-  type WalletProvider,
-} from '@aztec/wallet-sdk/manager';
-import { hashToEmoji } from '@aztec/wallet-sdk/crypto';
+import { WalletManager, type WalletProvider } from "@aztec/wallet-sdk/manager";
+import { hashToEmoji } from "@aztec/wallet-sdk/crypto";
 import type {
   AppCapabilities,
   GrantedAccountsCapability,
-} from '@aztec/aztec.js/wallet';
-import { getChainInfo } from '../../services/node';
-import { APP_ID, DISCOVERY_TIMEOUT_MS } from '../../config/app';
-import type { ConnectOptions, ConnectResult, WalletConnector } from './types';
+} from "@aztec/aztec.js/wallet";
+import { getChainInfo } from "../../services/node";
+import { APP_ID, DISCOVERY_TIMEOUT_MS } from "../../config/app";
+import type { ConnectOptions, ConnectResult, WalletConnector } from "./types";
 
 /** Take the first provider from the async iterator, or null if discovery is empty. */
 async function firstProvider(
-  wallets: AsyncIterable<WalletProvider>,
+  wallets: AsyncIterable<WalletProvider>
 ): Promise<WalletProvider | null> {
   for await (const provider of wallets) {
     return provider;
@@ -25,8 +22,8 @@ async function firstProvider(
 }
 
 export class ExternalConnector implements WalletConnector {
-  readonly kind = 'external' as const;
-  readonly label = 'Azguard';
+  readonly kind = "external" as const;
+  readonly label = "Azguard";
 
   // Active provider, kept so disconnect() can tear it down.
   private provider: WalletProvider | null = null;
@@ -44,7 +41,13 @@ export class ExternalConnector implements WalletConnector {
     const provider = await firstProvider(discovery.wallets);
     discovery.cancel();
     if (!provider) {
-      throw new Error('No external wallet found');
+      throw new Error("No external wallet found");
+    }
+    // Tear down any previous provider before replacing it, so its secure
+    // channel doesn't orphan (this connector is a long-lived singleton, so
+    // a reconnect without an explicit disconnect would overwrite it).
+    if (this.provider) {
+      await this.provider.disconnect();
     }
     this.provider = provider;
 
@@ -62,25 +65,27 @@ export class ExternalConnector implements WalletConnector {
 
     // External wallets (Azguard) use a capability/permission model: the dApp must
     // declare upfront which methods it needs. Without this, getAccounts() fails with
-    // "Unauthorized method/chain". We request the minimal `accounts` capability —
-    // the wallet shows a permission prompt and returns the granted accounts.
+    // "Unauthorized method/chain". We request the `accounts` capability — the
+    // wallet shows a permission prompt and returns the granted accounts.
     const manifest: AppCapabilities = {
-      version: '1.0',
+      version: "1.0",
       metadata: {
-        name: 'web-boiler',
-        version: '0.1.0',
-        description: 'Aztec frontend boilerplate',
+        name: "web-boiler",
+        version: "0.1.0",
+        description: "Aztec frontend boilerplate",
       },
-      capabilities: [{ type: 'accounts', canGet: true, canCreateAuthWit: true }],
+      capabilities: [
+        { type: "accounts", canGet: true, canCreateAuthWit: true },
+      ],
     };
     const response = await wallet.requestCapabilities(manifest);
 
     const accountsCap = response.granted.find(
-      (cap): cap is GrantedAccountsCapability => cap.type === 'accounts',
+      (cap): cap is GrantedAccountsCapability => cap.type === "accounts"
     );
     const accounts = accountsCap?.accounts ?? [];
     if (accounts.length === 0) {
-      throw new Error('No accounts granted by the external wallet');
+      throw new Error("No accounts granted by the external wallet");
     }
     // Return ALL granted accounts; the store lets the user pick which one
     // (the wallet may grant several). No more silent accounts[0].

--- a/src/lib/connectors/index.ts
+++ b/src/lib/connectors/index.ts
@@ -1,0 +1,25 @@
+// Connector registry: both paths produce the same wallet-agnostic `Wallet`.
+import { EmbeddedConnector } from './embedded';
+import { ExternalConnector } from './external';
+import type { ConnectorKind, WalletConnector } from './types';
+
+export type {
+  ConnectorKind,
+  WalletConnector,
+  ConnectOptions,
+  ConnectResult,
+  OnEmojiGrid,
+} from './types';
+export { EmbeddedConnector } from './embedded';
+export { ExternalConnector } from './external';
+
+/** Singleton instances of each available connector. */
+export const connectors: WalletConnector[] = [
+  new EmbeddedConnector(),
+  new ExternalConnector(),
+];
+
+/** Return the connector for the given `kind`, or `undefined` if none exists. */
+export function getConnector(kind: ConnectorKind): WalletConnector | undefined {
+  return connectors.find((c) => c.kind === kind);
+}

--- a/src/lib/connectors/types.ts
+++ b/src/lib/connectors/types.ts
@@ -1,0 +1,37 @@
+// Connector types: a unified shape for embedded + external wallets.
+// Both paths produce the SAME aztec.js `Wallet`; the difference is
+// encapsulated behind `WalletConnector`.
+import type { AztecNode } from '@aztec/aztec.js/node';
+import type { Wallet, Aliased } from '@aztec/aztec.js/wallet';
+import type { AztecAddress } from '@aztec/aztec.js/addresses';
+
+export type ConnectorKind = 'embedded' | 'external';
+
+/**
+ * Receives the emoji grid derived from the secure-channel handshake, purely for
+ * DISPLAY. Non-blocking: the connector shows the grid and proceeds immediately
+ * to confirm() (which triggers the wallet's own permission popup). The grid is
+ * the string from `hashToEmoji` (@aztec/wallet-sdk/crypto). Embedded ignores it.
+ */
+export type OnEmojiGrid = (emojiGrid: string) => void;
+
+export interface ConnectOptions {
+  node: AztecNode;
+  onEmojiGrid?: OnEmojiGrid;
+}
+
+export interface ConnectResult {
+  wallet: Wallet;
+  /**
+   * Accounts the wallet exposed. The store picks one automatically when there's
+   * a single account, or asks the user to choose when there are several.
+   */
+  accounts: Aliased<AztecAddress>[];
+}
+
+export interface WalletConnector {
+  kind: ConnectorKind;
+  label: string;
+  connect(opts: ConnectOptions): Promise<ConnectResult>;
+  disconnect(): Promise<void>;
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,24 @@
+// Formatting helpers shared across components.
+
+/**
+ * Truncate a long string (e.g. an Aztec address) to `head…tail`, keeping the
+ * first `head` and last `tail` characters. Returns the input unchanged when it
+ * is short enough that truncating wouldn't save space.
+ */
+export function truncateAddress(addr: string, head = 6, tail = 4): string {
+  if (addr.length <= head + tail + 1) return addr;
+  return `${addr.slice(0, head)}…${addr.slice(-tail)}`;
+}
+
+/**
+ * Split a string into individual user-perceived characters (graphemes). Uses
+ * `Intl.Segmenter` so multi-codepoint emojis stay intact, falling back to
+ * code-point iteration where `Segmenter` is unavailable.
+ */
+export function splitGraphemes(s: string): string[] {
+  if (typeof Intl !== 'undefined' && 'Segmenter' in Intl) {
+    const seg = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+    return Array.from(seg.segment(s), (g) => g.segment);
+  }
+  return Array.from(s); // fallback: by code point
+}

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,13 @@
+// Shared QueryClient instance for @tanstack/react-query.
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // On-chain data: avoid aggressive refetch on focus/reconnect.
+      staleTime: 5_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/src/services/node.ts
+++ b/src/services/node.ts
@@ -1,0 +1,22 @@
+// Aztec node client service.
+// createAztecNodeClient(VITE_AZTEC_NODE_URL) + getChainInfo helper.
+import { createAztecNodeClient, type AztecNode } from '@aztec/aztec.js/node';
+import { Fr } from '@aztec/aztec.js/fields';
+import type { ChainInfo } from '@aztec/aztec.js/account';
+
+/** Create a JSON-RPC client against the Aztec node (testnet via env). */
+export function createNode(url: string): AztecNode {
+  return createAztecNodeClient(url);
+}
+
+/**
+ * Derive the `ChainInfo` ({ chainId, version } as `Fr`) from the node.
+ * The external connector needs it for `WalletManager.getAvailableWallets`.
+ */
+export async function getChainInfo(node: AztecNode): Promise<ChainInfo> {
+  const { l1ChainId, rollupVersion } = await node.getNodeInfo();
+  return {
+    chainId: new Fr(l1ChainId),
+    version: new Fr(rollupVersion),
+  };
+}


### PR DESCRIPTION
Part 2/5 of the web-boiler migration.

Framework-agnostic logic and Aztec integration (no UI yet):
- config/app.ts        network definitions + app constants
- lib/format.ts        address truncation / grapheme helpers
- lib/queryClient.ts   TanStack Query client
- services/node.ts     Aztec node client (createNode, getChainInfo)
- lib/connectors/*     wallet connectors (embedded + external) behind
                       a shared WalletConnector interface

Not wired into the app yet; the build entry still renders the placeholder shell, so this part builds and lints clean.