### PR TITLE
feat: add wallet state store and React hooks

### DIFF
--- a/src/hooks/useBlockNumber.ts
+++ b/src/hooks/useBlockNumber.ts
@@ -1,0 +1,23 @@
+// useBlockNumber: polls the current block via react-query.
+// Reads node.getBlockNumber() from the store. BlockNumber is a branded number;
+// treat it as a number in the UI.
+import { useQuery } from '@tanstack/react-query';
+import { useWalletStore } from '../state/walletStore';
+
+export function useBlockNumber() {
+  const node = useWalletStore((s) => s.node);
+  const networkId = useWalletStore((s) => s.networkId);
+
+  return useQuery({
+    // Key on the network so switching nodes refetches instead of showing stale data.
+    queryKey: ['blockNumber', networkId],
+    queryFn: async () => {
+      if (!node) {
+        throw new Error('Node not initialized');
+      }
+      return node.getBlockNumber();
+    },
+    enabled: !!node,
+    refetchInterval: 10_000,
+  });
+}

--- a/src/hooks/useCopyToast.ts
+++ b/src/hooks/useCopyToast.ts
@@ -1,0 +1,36 @@
+// useCopyToast: copy text to the clipboard and confirm with a toast.
+//
+// Thin convenience over `useToast()` — encapsulates the clipboard write, the
+// insecure-context failure case, and the success toast, so callers just do:
+//
+//   const { copy } = useCopyToast();
+//   copy(address.toString(), 'Address copied to clipboard');
+//
+// Toast lifecycle (open/dismiss/animation) is owned by <ToastProvider>.
+import { useCallback } from 'react';
+import { useToast } from './useToast';
+
+export interface UseCopyToast {
+  /** Copy `text`; toasts `message` on success. Returns false if the clipboard
+   *  is unavailable (e.g. insecure context) — no toast in that case. */
+  copy: (text: string, message?: string) => Promise<boolean>;
+}
+
+export function useCopyToast(): UseCopyToast {
+  const { toast } = useToast();
+
+  const copy = useCallback(
+    async (text: string, message = 'Copied to clipboard'): Promise<boolean> => {
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch {
+        return false; // clipboard unavailable (e.g. insecure context)
+      }
+      toast(message);
+      return true;
+    },
+    [toast],
+  );
+
+  return { copy };
+}

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,25 @@
+// Toast context + hook. Kept separate from <ToastProvider> so the provider file
+// only exports a component (required by react-refresh / fast refresh).
+import { createContext, useContext } from 'react';
+
+export interface ToastOptions {
+  title: string;
+  /** Auto-dismiss after ms; falls back to the provider default. */
+  duration?: number;
+}
+
+export interface ToastContextValue {
+  /** Raise a toast. Pass a string for the common title-only case. */
+  toast: (opts: ToastOptions | string) => void;
+}
+
+export const ToastContext = createContext<ToastContextValue | null>(null);
+
+/** Access the imperative toast API. Must be used under <ToastProvider>. */
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error('useToast must be used within a <ToastProvider>');
+  }
+  return ctx;
+}

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,0 +1,32 @@
+// useWallet: convenience hook that exposes the whole wallet store as a single
+// object, so consumers can destructure just what they need:
+//
+//   const { status, address, connect } = useWallet();
+//
+
+import { useShallow } from "zustand/react/shallow";
+import { useWalletStore } from "../state/walletStore";
+
+export function useWallet() {
+  return useWalletStore(
+    useShallow((s) => ({
+      // state
+      node: s.node,
+      networkId: s.networkId,
+      status: s.status,
+      connector: s.connector,
+      address: s.address,
+      wallet: s.wallet,
+      error: s.error,
+      emojiGrid: s.emojiGrid,
+      pendingAccounts: s.pendingAccounts,
+      // actions (stable references)
+      initNetwork: s.initNetwork,
+      setNetwork: s.setNetwork,
+      connect: s.connect,
+      selectAccount: s.selectAccount,
+      disconnect: s.disconnect,
+      reconnect: s.reconnect,
+    }))
+  );
+}

--- a/src/lib/connectors/embedded.ts
+++ b/src/lib/connectors/embedded.ts
@@ -19,25 +19,46 @@ export class EmbeddedConnector implements WalletConnector {
     // Tear down a previous PXE before spinning up a new one (e.g. on a
     // network switch -> reconnect) so prover/worker resources don't leak.
     if (this.wallet) {
-      await this.wallet.stop();
+      await this.wallet.stop().catch((err) => {
+        console.warn("Failed to stop previous embedded wallet", err);
+      });
       this.wallet = null;
     }
 
-    // Use `pxe` (not the deprecated `pxeConfig`) in 4.3.0.
-    const wallet = await EmbeddedWallet.create(node, {
-      pxe: { proverEnabled: true },
-    });
-    this.wallet = wallet;
+    let wallet: EmbeddedWallet | null = null;
+    try {
+      // Use `pxe` (not the deprecated `pxeConfig`) in 4.3.0.
+      wallet = await EmbeddedWallet.create(node, {
+        pxe: { proverEnabled: true },
+      });
+      this.wallet = wallet;
 
-    // Reconnect: reuse a persisted account if present; otherwise create a
-    // Schnorr account. The signing key is derived automatically when omitted.
-    const accounts = await wallet.getAccounts();
-    if (accounts.length === 0) {
-      await wallet.createSchnorrAccount(Fr.random(), Fr.random());
+      // Reconnect: reuse a persisted account if present; otherwise create a
+      // Schnorr account. The signing key is derived automatically when omitted.
+      const accounts = await wallet.getAccounts();
+      if (accounts.length === 0) {
+        await wallet.createSchnorrAccount(Fr.random(), Fr.random());
+      }
+
+      const connectedWallet = wallet;
+      // Return the full account list; the store auto-selects when there's one.
+      return {
+        wallet: connectedWallet,
+        accounts: await wallet.getAccounts(),
+        disconnect: async () => {
+          await connectedWallet.stop();
+          if (this.wallet === connectedWallet) this.wallet = null;
+        },
+      };
+    } catch (err) {
+      if (wallet) {
+        await wallet.stop().catch((stopErr) => {
+          console.warn("Failed to stop embedded wallet after connect failure", stopErr);
+        });
+        if (this.wallet === wallet) this.wallet = null;
+      }
+      throw err;
     }
-
-    // Return the full account list; the store auto-selects when there's one.
-    return { wallet, accounts: await wallet.getAccounts() };
   }
 
   async disconnect(): Promise<void> {
@@ -45,8 +66,9 @@ export class EmbeddedConnector implements WalletConnector {
     // reconnects. The account itself stays in IndexedDB (persisted), so a
     // later reconnect reuses the same Schnorr account.
     if (this.wallet) {
-      await this.wallet.stop();
+      const wallet = this.wallet;
       this.wallet = null;
+      await wallet.stop();
     }
   }
 }

--- a/src/lib/connectors/external.ts
+++ b/src/lib/connectors/external.ts
@@ -29,73 +29,97 @@ export class ExternalConnector implements WalletConnector {
   private provider: WalletProvider | null = null;
 
   async connect({ node, onEmojiGrid }: ConnectOptions): Promise<ConnectResult> {
-    const chainInfo = await getChainInfo(node);
-    const discovery = WalletManager.configure({
-      extensions: { enabled: true },
-    }).getAvailableWallets({
-      chainInfo,
-      appId: APP_ID,
-      timeout: DISCOVERY_TIMEOUT_MS,
-    });
+    let provider: WalletProvider | null = null;
+    try {
+      const chainInfo = await getChainInfo(node);
+      const discovery = WalletManager.configure({
+        extensions: { enabled: true },
+      }).getAvailableWallets({
+        chainInfo,
+        appId: APP_ID,
+        timeout: DISCOVERY_TIMEOUT_MS,
+      });
 
-    const provider = await firstProvider(discovery.wallets);
-    discovery.cancel();
-    if (!provider) {
-      throw new Error("No external wallet found");
+      provider = await firstProvider(discovery.wallets);
+      discovery.cancel();
+      if (!provider) {
+        throw new Error("No external wallet found");
+      }
+      // Tear down any previous provider before replacing it, so its secure
+      // channel doesn't orphan (this connector is a long-lived singleton, so
+      // a reconnect without an explicit disconnect would overwrite it).
+      if (this.provider) {
+        const previousProvider = this.provider;
+        this.provider = null;
+        await previousProvider.disconnect().catch((err) => {
+          console.warn("Failed to disconnect previous external wallet provider", err);
+        });
+      }
+      this.provider = provider;
+
+      // Handshake: establish the secure channel (key exchange).
+      const pending = await provider.establishSecureChannel(APP_ID);
+
+      // Show the emoji grid for the user to compare against their wallet — but do
+      // NOT block on a confirm button. We proceed straight to confirm(), which
+      // hands control to the wallet (Azguard) to approve the connection + grant
+      // capabilities below. The grid stays on screen (the UI keeps it open while
+      // status === 'connecting') so the user can compare while the wallet prompts.
+      onEmojiGrid?.(hashToEmoji(pending.verificationHash));
+
+      const wallet = await pending.confirm();
+
+      // External wallets (Azguard) use a capability/permission model: the dApp must
+      // declare upfront which methods it needs. Without this, getAccounts() fails with
+      // "Unauthorized method/chain". We request the `accounts` capability — the
+      // wallet shows a permission prompt and returns the granted accounts.
+      const manifest: AppCapabilities = {
+        version: "1.0",
+        metadata: {
+          name: "web-boiler",
+          version: "0.1.0",
+          description: "Aztec frontend boilerplate",
+        },
+        capabilities: [
+          { type: "accounts", canGet: true, canCreateAuthWit: true },
+        ],
+      };
+      const response = await wallet.requestCapabilities(manifest);
+
+      const accountsCap = response.granted.find(
+        (cap): cap is GrantedAccountsCapability => cap.type === "accounts"
+      );
+      const accounts = accountsCap?.accounts ?? [];
+      if (accounts.length === 0) {
+        throw new Error("No accounts granted by the external wallet");
+      }
+      const connectedProvider = provider;
+      // Return ALL granted accounts; the store lets the user pick which one
+      // (the wallet may grant several). No more silent accounts[0].
+      return {
+        wallet,
+        accounts,
+        disconnect: async () => {
+          await connectedProvider.disconnect();
+          if (this.provider === connectedProvider) this.provider = null;
+        },
+      };
+    } catch (err) {
+      if (provider) {
+        await provider.disconnect().catch((disconnectErr) => {
+          console.warn("Failed to disconnect external provider after connect failure", disconnectErr);
+        });
+        if (this.provider === provider) this.provider = null;
+      }
+      throw err;
     }
-    // Tear down any previous provider before replacing it, so its secure
-    // channel doesn't orphan (this connector is a long-lived singleton, so
-    // a reconnect without an explicit disconnect would overwrite it).
-    if (this.provider) {
-      await this.provider.disconnect();
-    }
-    this.provider = provider;
-
-    // Handshake: establish the secure channel (key exchange).
-    const pending = await provider.establishSecureChannel(APP_ID);
-
-    // Show the emoji grid for the user to compare against their wallet — but do
-    // NOT block on a confirm button. We proceed straight to confirm(), which
-    // hands control to the wallet (Azguard) to approve the connection + grant
-    // capabilities below. The grid stays on screen (the UI keeps it open while
-    // status === 'connecting') so the user can compare while the wallet prompts.
-    onEmojiGrid?.(hashToEmoji(pending.verificationHash));
-
-    const wallet = await pending.confirm();
-
-    // External wallets (Azguard) use a capability/permission model: the dApp must
-    // declare upfront which methods it needs. Without this, getAccounts() fails with
-    // "Unauthorized method/chain". We request the `accounts` capability — the
-    // wallet shows a permission prompt and returns the granted accounts.
-    const manifest: AppCapabilities = {
-      version: "1.0",
-      metadata: {
-        name: "web-boiler",
-        version: "0.1.0",
-        description: "Aztec frontend boilerplate",
-      },
-      capabilities: [
-        { type: "accounts", canGet: true, canCreateAuthWit: true },
-      ],
-    };
-    const response = await wallet.requestCapabilities(manifest);
-
-    const accountsCap = response.granted.find(
-      (cap): cap is GrantedAccountsCapability => cap.type === "accounts"
-    );
-    const accounts = accountsCap?.accounts ?? [];
-    if (accounts.length === 0) {
-      throw new Error("No accounts granted by the external wallet");
-    }
-    // Return ALL granted accounts; the store lets the user pick which one
-    // (the wallet may grant several). No more silent accounts[0].
-    return { wallet, accounts };
   }
 
   async disconnect(): Promise<void> {
     if (this.provider) {
-      await this.provider.disconnect();
+      const provider = this.provider;
       this.provider = null;
+      await provider.disconnect();
     }
   }
 }

--- a/src/lib/connectors/types.ts
+++ b/src/lib/connectors/types.ts
@@ -27,6 +27,8 @@ export interface ConnectResult {
    * a single account, or asks the user to choose when there are several.
    */
   accounts: Aliased<AztecAddress>[];
+  /** Tear down the exact wallet/provider created for this connection. */
+  disconnect: () => Promise<void>;
 }
 
 export interface WalletConnector {

--- a/src/state/walletStore.ts
+++ b/src/state/walletStore.ts
@@ -86,6 +86,8 @@ export interface WalletState {
   pendingAccounts: Aliased<AztecAddress>[] | null;
   /** Monotonic token used to ignore stale async connection completions. */
   connectAttemptId: number;
+  /** Teardown for the exact active wallet/provider session. */
+  walletDisconnect: (() => Promise<void>) | null;
 
   /**
    * Create the node client for the persisted (or default) network and store it.
@@ -128,6 +130,7 @@ export const useWalletStore = create<WalletState>((set, get) => ({
   emojiGrid: null,
   pendingAccounts: null,
   connectAttemptId: 0,
+  walletDisconnect: null,
 
   initNetwork: () => {
     if (get().node) return;
@@ -157,6 +160,7 @@ export const useWalletStore = create<WalletState>((set, get) => ({
     }
 
     const previousConnector = get().connector;
+    const previousWalletDisconnect = get().walletDisconnect;
     const attemptId = get().connectAttemptId + 1;
     set({
       connectAttemptId: attemptId,
@@ -167,6 +171,7 @@ export const useWalletStore = create<WalletState>((set, get) => ({
       error: null,
       emojiGrid: null,
       pendingAccounts: null,
+      walletDisconnect: null,
     });
 
     const isCurrentAttempt = () => {
@@ -180,12 +185,15 @@ export const useWalletStore = create<WalletState>((set, get) => ({
     };
 
     try {
-      if (previousConnector) {
-        await disconnectConnector(previousConnector);
+      if (previousWalletDisconnect) {
+        await previousWalletDisconnect().catch(logConnectorDisconnectError);
+        if (!isCurrentAttempt()) return;
+      } else if (previousConnector) {
+        await disconnectConnector(previousConnector).catch(logConnectorDisconnectError);
         if (!isCurrentAttempt()) return;
       }
 
-      const { wallet, accounts } = await connector.connect({
+      const { wallet, accounts, disconnect } = await connector.connect({
         node,
         // Display-only: show the grid; the connector proceeds to the wallet popup.
         onEmojiGrid: (grid) => {
@@ -194,12 +202,12 @@ export const useWalletStore = create<WalletState>((set, get) => ({
       });
 
       if (!isCurrentAttempt()) {
-        await disconnectConnector(kind).catch(logConnectorDisconnectError);
+        await disconnect().catch(logConnectorDisconnectError);
         return;
       }
 
       if (accounts.length === 0) {
-        await disconnectConnector(kind).catch(logConnectorDisconnectError);
+        await disconnect().catch(logConnectorDisconnectError);
         if (!isCurrentAttempt()) return;
         set({
           status: 'error',
@@ -207,6 +215,7 @@ export const useWalletStore = create<WalletState>((set, get) => ({
           wallet: null,
           address: null,
           emojiGrid: null,
+          walletDisconnect: null,
         });
         return;
       }
@@ -222,6 +231,7 @@ export const useWalletStore = create<WalletState>((set, get) => ({
           error: null,
           emojiGrid: null,
           pendingAccounts: null,
+          walletDisconnect: disconnect,
         });
       } else {
         set({
@@ -230,11 +240,11 @@ export const useWalletStore = create<WalletState>((set, get) => ({
           pendingAccounts: accounts,
           error: null,
           emojiGrid: null,
+          walletDisconnect: disconnect,
         });
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      await disconnectConnector(kind).catch(logConnectorDisconnectError);
       if (!isCurrentAttempt()) return;
       set({
         status: 'error',
@@ -243,6 +253,7 @@ export const useWalletStore = create<WalletState>((set, get) => ({
         address: null,
         emojiGrid: null,
         pendingAccounts: null,
+        walletDisconnect: null,
       });
     }
   },
@@ -259,8 +270,9 @@ export const useWalletStore = create<WalletState>((set, get) => ({
   },
 
   disconnect: () => {
-    const { connector, connectAttemptId } = get();
-    void disconnectConnector(connector).catch(logConnectorDisconnectError);
+    const { connector, connectAttemptId, walletDisconnect } = get();
+    const disconnect = walletDisconnect ?? (() => disconnectConnector(connector));
+    void disconnect().catch(logConnectorDisconnectError);
     writeLastConnector(null);
     set({
       connectAttemptId: connectAttemptId + 1,
@@ -271,6 +283,7 @@ export const useWalletStore = create<WalletState>((set, get) => ({
       error: null,
       emojiGrid: null,
       pendingAccounts: null,
+      walletDisconnect: null,
     });
   },
 

--- a/src/state/walletStore.ts
+++ b/src/state/walletStore.ts
@@ -1,0 +1,229 @@
+// Zustand store for wallet connection state.
+// Keep the store focused on state + actions; no UI here.
+//
+// DESIGN DECISION (external handshake / emoji grid):
+// The external connector surfaces an emoji grid mid-connect() for the user to
+// compare against their wallet. It is DISPLAY-ONLY (no confirm button): the
+// connector proceeds straight to confirm(), which triggers the wallet's own
+// popup. The store exposes the grid as `emojiGrid` and clears it once the
+// connection settles, so the UI just shows a dialog while `emojiGrid !== null`.
+// The embedded connector never sets it. The store owns the callback internally.
+import { create } from 'zustand';
+import type { AztecNode } from '@aztec/aztec.js/node';
+import type { Wallet, Aliased } from '@aztec/aztec.js/wallet';
+import type { AztecAddress } from '@aztec/aztec.js/addresses';
+import { createNode } from '../services/node';
+import { getConnector } from '../lib/connectors';
+import type { ConnectorKind } from '../lib/connectors/types';
+import { DEFAULT_NETWORK_ID, getNetwork } from '../config/app';
+
+// Persist WHICH connector was last used so we can auto-reconnect on reload.
+// The embedded account already lives in IndexedDB (ephemeral: false), so
+// reconnecting embedded recovers the same account without creating a new one.
+const LAST_CONNECTOR_KEY = 'web-boiler:lastConnector';
+const NETWORK_KEY = 'web-boiler:network';
+
+function readNetworkId(): string {
+  try {
+    return localStorage.getItem(NETWORK_KEY) ?? DEFAULT_NETWORK_ID;
+  } catch {
+    return DEFAULT_NETWORK_ID;
+  }
+}
+
+function writeNetworkId(id: string) {
+  try {
+    localStorage.setItem(NETWORK_KEY, id);
+  } catch {
+    // ignore: localStorage unavailable
+  }
+}
+
+function readLastConnector(): ConnectorKind | null {
+  try {
+    const v = localStorage.getItem(LAST_CONNECTOR_KEY);
+    return v === 'embedded' || v === 'external' ? v : null;
+  } catch {
+    return null; // localStorage unavailable (private mode, etc.)
+  }
+}
+
+function writeLastConnector(kind: ConnectorKind | null) {
+  try {
+    if (kind) localStorage.setItem(LAST_CONNECTOR_KEY, kind);
+    else localStorage.removeItem(LAST_CONNECTOR_KEY);
+  } catch {
+    // ignore: localStorage unavailable
+  }
+}
+
+// 'selecting' = connected to the wallet, but the user still has to pick which
+// granted account to use (only when the wallet exposed more than one).
+export type WalletStatus = 'idle' | 'connecting' | 'selecting' | 'connected' | 'error';
+
+export interface WalletState {
+  node: AztecNode | null;
+  /** Active network id (see NETWORKS in config/app). */
+  networkId: string;
+  status: WalletStatus;
+  connector: ConnectorKind | null;
+  address: AztecAddress | null;
+  wallet: Wallet | null;
+  error: string | null;
+  /** Emoji grid to display during the external handshake; null when no dialog. */
+  emojiGrid: string | null;
+  /** Accounts to choose from while status === 'selecting'; null otherwise. */
+  pendingAccounts: Aliased<AztecAddress>[] | null;
+
+  /**
+   * Create the node client for the persisted (or default) network and store it.
+   * Idempotent: reuses an existing node. Call once on app load.
+   */
+  initNetwork: () => void;
+  /**
+   * Switch to another network: recreates the node client and tears down any
+   * active wallet (chainInfo differs per network, so the session can't carry over).
+   */
+  setNetwork: (id: string) => void;
+  /**
+   * Connect using the given connector. The external connector surfaces an emoji
+   * grid via `emojiGrid` (display-only) while the wallet prompts; embedded does not.
+   * If the wallet exposes >1 account, transitions to 'selecting' for the user to
+   * pick (via `selectAccount`); a single account is selected automatically.
+   */
+  connect: (kind: ConnectorKind) => Promise<void>;
+  /** Finalize a 'selecting' connection by choosing one of the pending accounts. */
+  selectAccount: (address: AztecAddress) => void;
+  /** Disconnect the active connector and reset wallet state. */
+  disconnect: () => void;
+  /**
+   * Auto-reconnect on load if the last session was embedded. Embedded-only:
+   * external requires a re-handshake (secure channel destroyed on reload) and
+   * we don't want to trigger the emoji flow without the user asking. Requires
+   * `initNetwork` to have run first.
+   */
+  reconnect: () => Promise<void>;
+}
+
+export const useWalletStore = create<WalletState>((set, get) => ({
+  node: null,
+  networkId: DEFAULT_NETWORK_ID,
+  status: 'idle',
+  connector: null,
+  address: null,
+  wallet: null,
+  error: null,
+  emojiGrid: null,
+  pendingAccounts: null,
+
+  initNetwork: () => {
+    if (get().node) return;
+    const net = getNetwork(readNetworkId());
+    set({ node: createNode(net.nodeUrl), networkId: net.id });
+  },
+
+  setNetwork: (id) => {
+    if (id === get().networkId && get().node) return;
+    const net = getNetwork(id);
+    // Tear down any active wallet first (resets state + clears lastConnector).
+    get().disconnect();
+    writeNetworkId(net.id);
+    set({ node: createNode(net.nodeUrl), networkId: net.id });
+  },
+
+  connect: async (kind) => {
+    const node = get().node;
+    if (!node) {
+      set({ status: 'error', error: 'Node not initialized' });
+      return;
+    }
+    const connector = getConnector(kind);
+    if (!connector) {
+      set({ status: 'error', error: `Unknown connector: ${kind}` });
+      return;
+    }
+
+    set({
+      status: 'connecting',
+      connector: kind,
+      error: null,
+      emojiGrid: null,
+      pendingAccounts: null,
+    });
+    try {
+      const { wallet, accounts } = await connector.connect({
+        node,
+        // Display-only: show the grid; the connector proceeds to the wallet popup.
+        onEmojiGrid: (grid) => set({ emojiGrid: grid }),
+      });
+
+      if (accounts.length === 0) {
+        set({
+          status: 'error',
+          error: 'No accounts available',
+          wallet: null,
+          address: null,
+          emojiGrid: null,
+        });
+        return;
+      }
+
+      // Keep the wallet either way; a single account is auto-selected, while
+      // several move to 'selecting' so the user picks one.
+      set({ wallet, emojiGrid: null });
+      if (accounts.length === 1) {
+        writeLastConnector(kind);
+        set({ status: 'connected', address: accounts[0].item, error: null, pendingAccounts: null });
+      } else {
+        set({ status: 'selecting', pendingAccounts: accounts, error: null });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      set({
+        status: 'error',
+        error: message,
+        wallet: null,
+        address: null,
+        emojiGrid: null,
+        pendingAccounts: null,
+      });
+    }
+  },
+
+  selectAccount: (address) => {
+    const { status, connector } = get();
+    if (status !== 'selecting') return;
+    if (connector) writeLastConnector(connector);
+    set({ status: 'connected', address, pendingAccounts: null, error: null });
+  },
+
+  disconnect: () => {
+    const { connector } = get();
+    if (connector) {
+      const c = getConnector(connector);
+      void c?.disconnect();
+    }
+    writeLastConnector(null);
+    set({
+      status: 'idle',
+      connector: null,
+      wallet: null,
+      address: null,
+      error: null,
+      emojiGrid: null,
+      pendingAccounts: null,
+    });
+  },
+
+  reconnect: async () => {
+    const { status, node } = get();
+    if (status === 'connecting' || status === 'selecting' || status === 'connected') return;
+    if (!node) return; // initNetwork must have run first
+    if (readLastConnector() !== 'embedded') return;
+
+    await get().connect('embedded');
+    // connect() doesn't throw: it sets status 'error'. If it failed, clear the
+    // flag so we don't retry-and-re-error on every reload.
+    if (get().status === 'error') writeLastConnector(null);
+  },
+}));

--- a/src/state/walletStore.ts
+++ b/src/state/walletStore.ts
@@ -57,6 +57,16 @@ function writeLastConnector(kind: ConnectorKind | null) {
   }
 }
 
+function logConnectorDisconnectError(err: unknown) {
+  console.warn('Failed to disconnect wallet connector', err);
+}
+
+async function disconnectConnector(kind: ConnectorKind | null) {
+  if (!kind) return;
+  const connector = getConnector(kind);
+  await connector?.disconnect();
+}
+
 // 'selecting' = connected to the wallet, but the user still has to pick which
 // granted account to use (only when the wallet exposed more than one).
 export type WalletStatus = 'idle' | 'connecting' | 'selecting' | 'connected' | 'error';
@@ -74,6 +84,8 @@ export interface WalletState {
   emojiGrid: string | null;
   /** Accounts to choose from while status === 'selecting'; null otherwise. */
   pendingAccounts: Aliased<AztecAddress>[] | null;
+  /** Monotonic token used to ignore stale async connection completions. */
+  connectAttemptId: number;
 
   /**
    * Create the node client for the persisted (or default) network and store it.
@@ -115,6 +127,7 @@ export const useWalletStore = create<WalletState>((set, get) => ({
   error: null,
   emojiGrid: null,
   pendingAccounts: null,
+  connectAttemptId: 0,
 
   initNetwork: () => {
     if (get().node) return;
@@ -143,21 +156,51 @@ export const useWalletStore = create<WalletState>((set, get) => ({
       return;
     }
 
+    const previousConnector = get().connector;
+    const attemptId = get().connectAttemptId + 1;
     set({
+      connectAttemptId: attemptId,
       status: 'connecting',
       connector: kind,
+      wallet: null,
+      address: null,
       error: null,
       emojiGrid: null,
       pendingAccounts: null,
     });
+
+    const isCurrentAttempt = () => {
+      const state = get();
+      return (
+        state.connectAttemptId === attemptId &&
+        state.status === 'connecting' &&
+        state.connector === kind &&
+        state.node === node
+      );
+    };
+
     try {
+      if (previousConnector) {
+        await disconnectConnector(previousConnector);
+        if (!isCurrentAttempt()) return;
+      }
+
       const { wallet, accounts } = await connector.connect({
         node,
         // Display-only: show the grid; the connector proceeds to the wallet popup.
-        onEmojiGrid: (grid) => set({ emojiGrid: grid }),
+        onEmojiGrid: (grid) => {
+          if (isCurrentAttempt()) set({ emojiGrid: grid });
+        },
       });
 
+      if (!isCurrentAttempt()) {
+        await disconnectConnector(kind).catch(logConnectorDisconnectError);
+        return;
+      }
+
       if (accounts.length === 0) {
+        await disconnectConnector(kind).catch(logConnectorDisconnectError);
+        if (!isCurrentAttempt()) return;
         set({
           status: 'error',
           error: 'No accounts available',
@@ -170,15 +213,29 @@ export const useWalletStore = create<WalletState>((set, get) => ({
 
       // Keep the wallet either way; a single account is auto-selected, while
       // several move to 'selecting' so the user picks one.
-      set({ wallet, emojiGrid: null });
       if (accounts.length === 1) {
         writeLastConnector(kind);
-        set({ status: 'connected', address: accounts[0].item, error: null, pendingAccounts: null });
+        set({
+          status: 'connected',
+          wallet,
+          address: accounts[0].item,
+          error: null,
+          emojiGrid: null,
+          pendingAccounts: null,
+        });
       } else {
-        set({ status: 'selecting', pendingAccounts: accounts, error: null });
+        set({
+          status: 'selecting',
+          wallet,
+          pendingAccounts: accounts,
+          error: null,
+          emojiGrid: null,
+        });
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      await disconnectConnector(kind).catch(logConnectorDisconnectError);
+      if (!isCurrentAttempt()) return;
       set({
         status: 'error',
         error: message,
@@ -191,20 +248,22 @@ export const useWalletStore = create<WalletState>((set, get) => ({
   },
 
   selectAccount: (address) => {
-    const { status, connector } = get();
+    const { status, connector, pendingAccounts } = get();
     if (status !== 'selecting') return;
+    if (!pendingAccounts?.some((account) => account.item.equals(address))) {
+      set({ status: 'error', error: 'Selected account was not granted by the wallet' });
+      return;
+    }
     if (connector) writeLastConnector(connector);
     set({ status: 'connected', address, pendingAccounts: null, error: null });
   },
 
   disconnect: () => {
-    const { connector } = get();
-    if (connector) {
-      const c = getConnector(connector);
-      void c?.disconnect();
-    }
+    const { connector, connectAttemptId } = get();
+    void disconnectConnector(connector).catch(logConnectorDisconnectError);
     writeLastConnector(null);
     set({
+      connectAttemptId: connectAttemptId + 1,
       status: 'idle',
       connector: null,
       wallet: null,


### PR DESCRIPTION
Part 3/5 of the web-boiler migration.

Client state and the React surface over it:
- state/walletStore.ts   Zustand store: network/connection lifecycle,
                         node bootstrap, connect/reconnect/disconnect
- hooks/useToast.ts      toast context hook
- hooks/useWallet.ts     selector hook over the wallet store
- hooks/useBlockNumber.ts  live block number (TanStack Query)
- hooks/useCopyToast.ts  copy-to-clipboard with toast feedback

Builds on part 2's services/connectors. Still not mounted by the placeholder shell, so it builds and lints clean.